### PR TITLE
feat: add support for defining in-template @events

### DIFF
--- a/docs/guide/components-events.md
+++ b/docs/guide/components-events.md
@@ -24,9 +24,7 @@ class MyElement extends MinzeElement {
     </button>
   `
 
-  handleClick = (event) => {
-    console.log(event)
-  }
+  handleClick = () => console.log('clicked')
 }
 
 MyElement.define()

--- a/docs/guide/components-events.md
+++ b/docs/guide/components-events.md
@@ -2,6 +2,40 @@
 
 Events can be used to communicate between components and the outside world.
 
+## @events
+
+`@events` are a shorthand form of [Event Listeners](#event-listeners) that are directly defined inside the html template as attributes.
+
+**Structure:** The attribute name starts with an `@` sign and is directly followed by a valid [JavaScript DOM event type](https://en.wikipedia.org/wiki/DOM_event#HTML_events), the value of the attribute is the name of the method, that should be called when the event is triggered. `@click="callback"`
+
+::: warning
+`@events` only work with methods defined on the component class.
+:::
+
+**Example**
+
+```js
+import { MinzeElement } from 'minze'
+
+class MyElement extends MinzeElement {
+  html = () => `
+    <button @click="handleClick">
+      Button
+    </button>
+  `
+
+  handleClick = (event) => {
+    console.log(event)
+  }
+}
+
+MyElement.define()
+```
+
+```html
+<my-element></my-element>
+```
+
 ## Event Listeners
 
 An event Listener can listen for specific events and run a callback function whenever the event is triggered.

--- a/packages/tests/e2e/minze-element/src/lib/minze-@events.spec.ts
+++ b/packages/tests/e2e/minze-element/src/lib/minze-@events.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test'
+import { start } from '@tests/minze-element/utils'
+
+const element = 'minze-at-events'
+
+test(`MinzeElement: ${element}`, async ({ page }) => {
+  const template = `<${element}></${element}>`
+  await start(page, template)
+
+  const selector = `${element} button`
+
+  expect(await page.locator(selector).innerText()).toBe('not-clicked')
+
+  await page.click(selector)
+
+  expect(await page.locator(selector).innerText()).toBe('clicked')
+})

--- a/packages/tests/e2e/minze-element/src/lib/minze-@events.ts
+++ b/packages/tests/e2e/minze-element/src/lib/minze-@events.ts
@@ -1,7 +1,12 @@
+import type { Reactive } from 'minze'
 import { MinzeElement } from 'minze'
 
+export interface MinzeAtEvents {
+  text: string
+}
+
 export class MinzeAtEvents extends MinzeElement {
-  text = 'not-clicked'
+  reactive: Reactive = [['text', 'not-clicked']]
 
   changeText = () => (this.text = 'clicked')
 

--- a/packages/tests/e2e/minze-element/src/lib/minze-@events.ts
+++ b/packages/tests/e2e/minze-element/src/lib/minze-@events.ts
@@ -1,0 +1,13 @@
+import { MinzeElement } from 'minze'
+
+export class MinzeAtEvents extends MinzeElement {
+  text = 'not-clicked'
+
+  changeText = () => (this.text = 'clicked')
+
+  html = () => `
+    <button @click="changeText">
+      ${this.text}
+    </button>
+  `
+}


### PR DESCRIPTION
<!-- Thank's for contributing! -->

### Description

Adds the functionality to define event listeners directly inside the HTML template.

**Example**

```js
import { MinzeElement } from 'minze'

class MyElement extends MinzeElement {
  html = () => `
    <button @click="handleClick">
      Button
    </button>
  `

  handleClick = () => console.log('clicked')
}

MyElement.define()
```

```html
<my-element></my-element>
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/n6ai/minze/blob/main/.github/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/n6ai/minze/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/n6ai/minze/blob/main/.github/COMMIT_CONVENTION.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
