### PR TITLE
fix: exportparts extraction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1792,8 +1792,6 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -2973,6 +2971,12 @@
         "node": "^16.13 || >=18"
       }
     },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "dev": true
+    },
     "node_modules/acorn": {
       "version": "8.9.0",
       "license": "MIT",
@@ -3005,8 +3009,6 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -3953,9 +3955,69 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
+      "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
+      "dev": true,
+      "dependencies": {
+        "rrweb-cssom": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.2",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
+      "integrity": "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
+      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/date-fns": {
       "version": "2.30.0",
@@ -4007,6 +4069,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+      "dev": true
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -4228,6 +4296,27 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ]
+    },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "dev": true,
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/domexception/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
@@ -5465,6 +5554,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
@@ -5497,8 +5598,6 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@tootallnate/once": "2",
         "agent-base": "6",
@@ -5528,8 +5627,6 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -5545,6 +5642,18 @@
       "dev": true,
       "engines": {
         "node": ">=14.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -5766,6 +5875,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
     "node_modules/is-reference": {
       "version": "3.0.1",
       "license": "MIT",
@@ -5861,6 +5976,82 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-22.1.0.tgz",
+      "integrity": "sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.6",
+        "cssstyle": "^3.0.0",
+        "data-urls": "^4.0.0",
+        "decimal.js": "^10.4.3",
+        "domexception": "^4.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.4",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^12.0.1",
+        "ws": "^8.13.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
+      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/jsesc": {
@@ -6982,6 +7173,12 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
+      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==",
+      "dev": true
+    },
     "node_modules/object-inspect": {
       "version": "1.12.3",
       "dev": true,
@@ -7455,6 +7652,12 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+      "dev": true
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -7467,9 +7670,10 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -7531,6 +7735,12 @@
       "dev": true,
       "optional": true,
       "peer": true
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -7870,6 +8080,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
+    },
     "node_modules/resolve": {
       "version": "1.22.1",
       "dev": true,
@@ -8070,6 +8286,12 @@
         "typescript": "^4.1 || ^5.0"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+      "dev": true
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "dev": true,
@@ -8124,11 +8346,29 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
     "node_modules/sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.0",
@@ -8672,6 +8912,12 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
     "node_modules/tabbable": {
       "version": "6.2.0",
       "dev": true,
@@ -8815,6 +9061,30 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/tr46": {
@@ -9030,6 +9300,16 @@
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -9336,6 +9616,18 @@
         "typescript": "*"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dev": true,
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/wait-on": {
       "version": "7.0.1",
       "dev": true,
@@ -9451,6 +9743,27 @@
       "dev": true,
       "optional": true,
       "peer": true
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -9589,8 +9902,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
       "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -9605,6 +9916,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/xml2js": {
@@ -9628,6 +9948,12 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -9891,6 +10217,7 @@
       "devDependencies": {
         "@playwright/test": "^1.36.2",
         "@vitest/ui": "^0.32.4",
+        "jsdom": "^22.1.0",
         "typescript": "^5.1.6",
         "vite": "^4.4.7",
         "vitest": "^0.32.4"

--- a/packages/minze/src/lib/minze-element.ts
+++ b/packages/minze/src/lib/minze-element.ts
@@ -817,7 +817,7 @@ export class MinzeElement extends HTMLElement {
       )
     ]
 
-    this.setAttribute('exportparts', parts.join(', '))
+    if (parts.length) this.setAttribute('exportparts', parts.join(', '))
   }
 
   /**

--- a/packages/minze/src/lib/minze-element.ts
+++ b/packages/minze/src/lib/minze-element.ts
@@ -810,7 +810,9 @@ export class MinzeElement extends HTMLElement {
     // get all parts inside the template
     const partsRE = /(?:part|exportparts)=["']?([\w\-_,\s]+)["']?/gi
     const parts = [
-      ...new Set([...template.matchAll(partsRE)].map((m) => m.at(1)))
+      ...new Set(
+        [...template.matchAll(partsRE)].flatMap((m) => m.at(1)?.split(','))
+      )
     ]
 
     this.setAttribute('exportparts', parts.join(', '))

--- a/packages/minze/src/lib/minze-element.ts
+++ b/packages/minze/src/lib/minze-element.ts
@@ -811,7 +811,9 @@ export class MinzeElement extends HTMLElement {
     const partsRE = /(?:part|exportparts)=["']?([\w\-_,\s]+)["']?/gi
     const parts = [
       ...new Set(
-        [...template.matchAll(partsRE)].flatMap((m) => m.at(1)?.split(','))
+        [...template.matchAll(partsRE)].flatMap((m) => {
+          return m.at(1)?.replace(/,?\s+/g, ',').split(',')
+        })
       )
     ]
 

--- a/packages/minze/src/lib/minze-element.ts
+++ b/packages/minze/src/lib/minze-element.ts
@@ -834,7 +834,7 @@ export class MinzeElement extends HTMLElement {
     const add = action === 'add' && !this[key]
     const remove = action === 'remove' && this[key]
 
-    if (add) {
+    if (add && this.shadowRoot) {
       const callback: MutationCallback = (mutations) => {
         if (mutations && this.shadowRoot) {
           this.exportParts(this.shadowRoot.innerHTML)
@@ -843,7 +843,7 @@ export class MinzeElement extends HTMLElement {
 
       const options = { subtree: true, attributeFilter: ['exportparts'] }
 
-      this[key] = createObserver(this, callback, options)
+      this[key] = createObserver(this.shadowRoot, callback, options)
     } else if (remove) {
       this[key].disconnect()
       delete this[key]

--- a/packages/minze/src/lib/utils.ts
+++ b/packages/minze/src/lib/utils.ts
@@ -1,5 +1,3 @@
-import { MinzeElement } from './minze-element'
-
 /**
  * Creates a symbol that makes it possible to check
  * if an object is a proxy.
@@ -53,7 +51,7 @@ export function dashToCamel(value: string) {
  * ```
  */
 export function createObserver(
-  element: Node | ShadowRoot | MinzeElement,
+  element: Node | ShadowRoot,
   callback: MutationCallback,
   options: MutationObserverInit = {
     attributes: true,
@@ -61,9 +59,6 @@ export function createObserver(
     subtree: true
   }
 ) {
-  if (element instanceof MinzeElement && element.shadowRoot)
-    element = element.shadowRoot
-
   const observer = new MutationObserver(callback)
   observer.observe(element, options)
 

--- a/packages/minze/src/lib/utils.ts
+++ b/packages/minze/src/lib/utils.ts
@@ -1,3 +1,5 @@
+import { MinzeElement } from './minze-element'
+
 /**
  * Creates a symbol that makes it possible to check
  * if an object is a proxy.
@@ -33,6 +35,39 @@ export function camelToDash(value: string) {
  */
 export function dashToCamel(value: string) {
   return value.replace(/-([a-z])/g, (g) => g[1].toUpperCase())
+}
+
+/**
+ * Creates an mutation observer and starts observation.
+ *
+ * @param element - The element node to observe.
+ * @param callback - Mutation observer Callback function.
+ * @param options - Mutation observer options. If non provided default options will be used.
+ *
+ * @default
+ * options = { attributes: true, childList: true, subtree: true }
+ *
+ * @example
+ * ```
+ * createObserver(this, () => {}, { attributes})
+ * ```
+ */
+export function createObserver(
+  element: Node | ShadowRoot | MinzeElement,
+  callback: MutationCallback,
+  options: MutationObserverInit = {
+    attributes: true,
+    childList: true,
+    subtree: true
+  }
+) {
+  if (element instanceof MinzeElement && element.shadowRoot)
+    element = element.shadowRoot
+
+  const observer = new MutationObserver(callback)
+  observer.observe(element, options)
+
+  return observer
 }
 
 /**

--- a/packages/tests/README.md
+++ b/packages/tests/README.md
@@ -19,13 +19,13 @@ npm test
 
 ```bash
 # run vitest tests
-npm run test-v
+npm run test-vi
 
 # run specific tests based on their filenames
-npm run test-v -- utils.spec.ts
+npm run test-vi -- utils.spec.ts
 
 # run specific tests with keywords in their filenames
-npm run test-v -- utils lib
+npm run test-vi -- utils lib
 ```
 
 **Playwright**

--- a/packages/tests/e2e/minze-element/src/lib/minze-exportparts.spec.ts
+++ b/packages/tests/e2e/minze-element/src/lib/minze-exportparts.spec.ts
@@ -18,6 +18,6 @@ test(`MinzeElement: ${element}`, async ({ page }) => {
 
   await expect(page.locator(element)).toHaveAttribute(
     'exportparts',
-    'button, button--primmary, another-part'
+    'button, button--primary, another-part'
   )
 })

--- a/packages/tests/e2e/minze-element/src/lib/minze-exportparts.spec.ts
+++ b/packages/tests/e2e/minze-element/src/lib/minze-exportparts.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test'
+import { start } from '@tests/minze-element/utils'
+
+const element = 'minze-exportparts'
+
+test(`MinzeElement: ${element}`, async ({ page }) => {
+  const template = `<${element}></${element}>`
+  await start(page, template)
+
+  const selector = `${element} button`
+
+  await expect(page.locator(element)).toHaveAttribute(
+    'exportparts',
+    'button, button--primary'
+  )
+
+  await page.click(selector)
+
+  await expect(page.locator(element)).toHaveAttribute(
+    'exportparts',
+    'button, button--primmary, another-part'
+  )
+})

--- a/packages/tests/e2e/minze-element/src/lib/minze-exportparts.ts
+++ b/packages/tests/e2e/minze-element/src/lib/minze-exportparts.ts
@@ -1,0 +1,24 @@
+import type { Reactive } from 'minze'
+import { MinzeElement } from 'minze'
+
+export interface MinzeExportparts {
+  clicked: boolean
+}
+
+export class MinzeExportparts extends MinzeElement {
+  options = { exposeAttrs: { exportparts: true } }
+
+  reactive: Reactive = [['clicked', false]]
+
+  click = () => (this.clicked = true)
+
+  html = () => `
+    <button
+      @click="click"
+      part="button button--primary"
+      ${this.clicked ? 'exportparts="button,  another-part"' : ''}
+    >
+      Button
+    </button>
+  `
+}

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "test": "npm run test-v && npm run test-pw",
+    "test": "npm run test-vi && npm run test-pw",
     "test-vi": "vitest --run",
     "test-vi-ui": "vitest --ui",
     "test-pw": "npx playwright test",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "dev": "vite",
     "test": "npm run test-v && npm run test-pw",
-    "test-v": "vitest --run",
-    "test-v-ui": "vitest --ui",
+    "test-vi": "vitest --run",
+    "test-vi-ui": "vitest --ui",
     "test-pw": "npx playwright test",
     "test-pw-ui": "npx playwright test --ui",
     "test-pw-debug": "npx playwright test --debug"
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@playwright/test": "^1.36.2",
     "@vitest/ui": "^0.32.4",
+    "jsdom": "^22.1.0",
     "typescript": "^5.1.6",
     "vite": "^4.4.7",
     "vitest": "^0.32.4"

--- a/packages/tests/unit/utils.spec.ts
+++ b/packages/tests/unit/utils.spec.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi } from 'vitest'
-import { isProxy, camelToDash, dashToCamel, warn } from 'minze/src/lib/utils'
+import {
+  isProxy,
+  camelToDash,
+  dashToCamel,
+  createObserver,
+  warn
+} from 'minze/src/lib/utils'
 
 describe('isProxy', () => {
   it('should return true if the object is a proxy', () => {
@@ -53,6 +59,16 @@ describe('dashToCamel', () => {
       expect(dashToCamel(input)).toBe(expected)
     }
   )
+})
+
+// @vitest-environment jsdom
+describe('createObserver', () => {
+  it('should return an Mutation Observer', () => {
+    const element = document.createElement('div')
+    const observer = createObserver(element, () => {})
+
+    expect(observer).toBeInstanceOf(MutationObserver)
+  })
 })
 
 describe('warn', () => {


### PR DESCRIPTION
<!-- Thank's for contributing! -->

### Description

PR fixes:
- `exportparts` extraction process for deeply nested elements
- extracts now multiple parts from a single part attribute if present
- removes extensive whitespace from part/exportparts attrs
- removes duplicate names in part/exportparts

Example:

```html
<custom-el part="el el-primary">
  <custom-el-2 exportparts="el-2, el-2-primary"></custom-el-2>
</custom-el>
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/n6ai/minze/blob/main/.github/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/n6ai/minze/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/n6ai/minze/blob/main/.github/COMMIT_CONVENTION.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
