### PR TITLE
feat: add debug option, name & dashName properties

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -329,6 +329,10 @@ export default defineConfig({
               link: '/guide/advanced-syntax-highlighting'
             },
             {
+              text: 'Debugging',
+              link: '/guide/advanced-debugging'
+            },
+            {
               text: 'Mixins',
               link: '/guide/advanced-mixins'
             },

--- a/docs/api/minze-element.md
+++ b/docs/api/minze-element.md
@@ -44,23 +44,69 @@ class MyElement extends MinzeElement {}
 console.log(MyElement.isMinzeElement) // true
 ```
 
-### dashName <Badge type="tip" text="^1.2.0" />
+### name <Badge type="tip" text="^1.9.0" />
 
-The class name of the component in dash-case.
+The class name of the component.
 
-- **Static Getter**
+- **Static Getter / Getter**
 
 - **Type:** `getter`
 
 - **Example:**
 
-```js
+::: code-group
+
+```js [outside]
+import { MinzeElement } from 'minze'
+
+class MyElement extends MinzeElement {}
+
+console.log(MyElement.name) // MyElement
+```
+
+```js [inside]
+import { MinzeElement } from 'minze'
+
+class MyElement extends MinzeElement {
+  onStart() {
+    console.log(this.name) // MyElement
+  }
+}
+```
+
+:::
+
+### dashName <Badge type="tip" text="^1.9.0" />
+
+The class name of the component in dash-case.
+
+- **Static Getter / Getter**
+
+- **Type:** `getter`
+
+- **Example:**
+
+::: code-group
+
+```js [outside]
 import { MinzeElement } from 'minze'
 
 class MyElement extends MinzeElement {}
 
 console.log(MyElement.dashName) // my-element
 ```
+
+```js [inside]
+import { MinzeElement } from 'minze'
+
+class MyElement extends MinzeElement {
+  onStart() {
+    console.log(this.dashName) // my-element
+  }
+}
+```
+
+:::
 
 ### define <Badge type="tip" text="^1.0.0" />
 

--- a/docs/api/minze-element.md
+++ b/docs/api/minze-element.md
@@ -817,11 +817,11 @@ import { MinzeElement } from 'minze'
 
 export class MyElement extends MinzeElement {
   options = {
-    cssReset: true, // Applies CSS reset styles to the components Shadow DOM template.
-    debug: false, // Activates debug mode on the component, check the web console for output.
+    cssReset: true, // Apply CSS reset styles to the components Shadow DOM.
+    debug: false, // Log information about the component to the console.
     exposeAttrs: {
-      exportparts: false, // Automatically exports all parts present in the template. E.g. <my-element exportparts="button, headline"></my-element>
-      rendered: false // After the component is rendered for the first time, exposes a 'rendered' attribute on the element. E.g. <my-element rendered></my-element>
+      exportparts: false, // Expose an 'exportparts' attribute on the element that includes all parts present in the component. E.g. <my-element exportparts="button, headline"></my-element>
+      rendered: false // Expose a 'rendered' attribute on the element, after it's rendered for the first time. E.g. <my-element rendered></my-element>
     }
   }
 }

--- a/docs/api/minze-element.md
+++ b/docs/api/minze-element.md
@@ -4,8 +4,8 @@ Base class which can be used to extend from to create custom web components.
 
 ## READ-ONLY
 
-::: warning
-Read-only Properties/Getters/Methods are present on every single component from the start, ready for usage, but shouldn't be altered.
+::: tip
+Read-only Properties/Getters/Methods are present on every component class extending MinzeElement.
 :::
 
 ### version <Badge type="tip" text="^1.2.0" />
@@ -56,7 +56,7 @@ The class name of the component.
 
 ::: code-group
 
-```js [outside]
+```js [class]
 import { MinzeElement } from 'minze'
 
 class MyElement extends MinzeElement {}
@@ -64,7 +64,7 @@ class MyElement extends MinzeElement {}
 console.log(MyElement.name) // MyElement
 ```
 
-```js [inside]
+```js [instance]
 import { MinzeElement } from 'minze'
 
 class MyElement extends MinzeElement {
@@ -88,7 +88,7 @@ The class name of the component in dash-case.
 
 ::: code-group
 
-```js [outside]
+```js [class]
 import { MinzeElement } from 'minze'
 
 class MyElement extends MinzeElement {}
@@ -96,7 +96,7 @@ class MyElement extends MinzeElement {}
 console.log(MyElement.dashName) // my-element
 ```
 
-```js [inside]
+```js [intance]
 import { MinzeElement } from 'minze'
 
 class MyElement extends MinzeElement {

--- a/docs/api/minze-element.md
+++ b/docs/api/minze-element.md
@@ -2,10 +2,10 @@
 
 Base class which can be used to extend from to create custom web components.
 
-## STATIC
+## READ-ONLY
 
 ::: warning
-Static Properties/Getters/Methods are present on every single component from the start and shouldn't be altered.
+Read-only Properties/Getters/Methods are present on every single component from the start, ready for usage, but shouldn't be altered.
 :::
 
 ### version <Badge type="tip" text="^1.2.0" />
@@ -143,36 +143,7 @@ MyElement.define('my-custom-element')
 ```
 <!-- prettier-ignore-end -->
 
-## DYNAMIC
-
-::: tip
-Dynamic Properties/Getters/Methods can be defined on each component individually and usually differ from component to component.
-:::
-
-### options <Badge type="tip" text="^1.0.0" />
-
-Individual components can be customized by declaring an options property. All currently available options are listed in the example below with their **default values**.
-
-- **Property**
-
-- **Type:** `Object`
-
-- **Example:**
-
-```js
-import { MinzeElement } from 'minze'
-
-export class MyElement extends MinzeElement {
-  options = {
-    cssReset: true, // Applies CSS reset styles to the components Shadow DOM template.
-    debug: false, // Activates debug mode on the component, check the web console for output.
-    exposeAttrs: {
-      exportparts: false, // Automatically exports all parts present in the template. E.g. <my-element exportparts="button, headline"></my-element>
-      rendered: false // After the component is rendered for the first time, exposes a 'rendered' attribute on the element. E.g. <my-element rendered></my-element>
-    }
-  }
-}
-```
+## DATA
 
 ### reactive <Badge type="tip" text="^1.0.0" />
 
@@ -379,75 +350,6 @@ export class MyElement extends MinzeElement {
 }
 ```
 
-### eventListeners <Badge type="tip" text="^1.0.0" />
-
-Dynamically creates event listeners, either on/inside the component or on the `window` object. `eventListeners` should be an array containing one or more tuples. In JavaScript, tuples are ordinary arrays, but in TypeScript they are their own type, defining the length of the array and the types of its elements.
-
-Every tuple takes exactly 3 values.
-
-Tuple structure: [`eventTarget`, `eventName`, `callback`]
-
-1. **eventTarget:** where the event listener should be attached to. Can be a valid CSS selector (for elements inside the `html` property), `this` (The component itself) or `window`.
-2. **eventName:** the name of the event to listen to.
-3. **callback:** a callback function that runs when the eventName is matched.
-
-::: warning
-Web components are meant to be encapsulated HTML elements, it's a bad idea to create event listeners inside the component and attach them all over the place. That's why the targets outside of the component are intentionally limited to the `window` object, to prevent `event-listener-pollution`.
-:::
-
-::: danger
-When passing a method as a callback, make sure it's either defined as an arrow function or properly bound to the component.
-:::
-
-- **Property**
-
-- **Type:** `readonly [eventTarget: string | MinzeElement | typeof Window, eventName: string, callback: (event: Event) => void][]`
-
-- **Example:**
-
-```js
-import { MinzeElement } from 'minze'
-
-export class MyElement extends MinzeElement {
-  html = () => `
-    <button class="button">
-      Button
-    </button>
-  `
-
-  handleClick = () => {
-    const optionalDetail = {
-      msg: 'Hello Minze!'
-    }
-
-    this.dispatch('minze:my-event-name', optionalDetail)
-  }
-
-  handleDispatch = (event) => {
-    console.log(event.detail)
-  }
-
-  /*
-   * Passing a callback to eventListeners
-   *
-   * Regular methods have to be bound to the component
-   * in order to access any properties or methods of the component.
-   * Properties defined with arrow functions don't need to be bound,
-   * since they don't have their own 'this' binding
-   * and instead are bound to the component by default.
-   */
-  handleNestedDispatch(event) {
-    console.log(event.detail)
-  }
-
-  eventListeners = [
-    ['.button', 'click', this.handleClick],
-    [window, 'minze:my-event-name', this.handleDispatch],
-    [this, 'minze:my-nested-event-name', this.handleNestedDispatch.bind(this)]
-  ]
-}
-```
-
 ## TEMPLATE
 
 ### html <Badge type="tip" text="^1.0.0" />
@@ -610,6 +512,75 @@ export class MyElement extends MinzeElement {
 ```
 
 ## EVENTS
+
+### eventListeners <Badge type="tip" text="^1.0.0" />
+
+Dynamically creates event listeners, either on/inside the component or on the `window` object. `eventListeners` should be an array containing one or more tuples. In JavaScript, tuples are ordinary arrays, but in TypeScript they are their own type, defining the length of the array and the types of its elements.
+
+Every tuple takes exactly 3 values.
+
+Tuple structure: [`eventTarget`, `eventName`, `callback`]
+
+1. **eventTarget:** where the event listener should be attached to. Can be a valid CSS selector (for elements inside the `html` property), `this` (The component itself) or `window`.
+2. **eventName:** the name of the event to listen to.
+3. **callback:** a callback function that runs when the eventName is matched.
+
+::: warning
+Web components are meant to be encapsulated HTML elements, it's a bad idea to create event listeners inside the component and attach them all over the place. That's why the targets outside of the component are intentionally limited to the `window` object, to prevent `event-listener-pollution`.
+:::
+
+::: danger
+When passing a method as a callback, make sure it's either defined as an arrow function or properly bound to the component.
+:::
+
+- **Property**
+
+- **Type:** `readonly [eventTarget: string | MinzeElement | typeof Window, eventName: string, callback: (event: Event) => void][]`
+
+- **Example:**
+
+```js
+import { MinzeElement } from 'minze'
+
+export class MyElement extends MinzeElement {
+  html = () => `
+    <button class="button">
+      Button
+    </button>
+  `
+
+  handleClick = () => {
+    const optionalDetail = {
+      msg: 'Hello Minze!'
+    }
+
+    this.dispatch('minze:my-event-name', optionalDetail)
+  }
+
+  handleDispatch = (event) => {
+    console.log(event.detail)
+  }
+
+  /*
+   * Passing a callback to eventListeners
+   *
+   * Regular methods have to be bound to the component
+   * in order to access any properties or methods of the component.
+   * Properties defined with arrow functions don't need to be bound,
+   * since they don't have their own 'this' binding
+   * and instead are bound to the component by default.
+   */
+  handleNestedDispatch(event) {
+    console.log(event.detail)
+  }
+
+  eventListeners = [
+    ['.button', 'click', this.handleClick],
+    [window, 'minze:my-event-name', this.handleDispatch],
+    [this, 'minze:my-nested-event-name', this.handleNestedDispatch.bind(this)]
+  ]
+}
+```
 
 ### dispatch <Badge type="tip" text="^1.3.2" />
 
@@ -825,6 +796,33 @@ import { MinzeElement } from 'minze'
 export class MyElement extends MinzeElement {
   onAttributeChange(name, oldValue, newValue) {
     console.log('onAttributeChange: ', name, oldValue, newValue)
+  }
+}
+```
+
+## MISC
+
+### options <Badge type="tip" text="^1.0.0" />
+
+Individual components can be customized by declaring an options property. All currently available options are listed in the example below with their **default values**.
+
+- **Property**
+
+- **Type:** `Object`
+
+- **Example:**
+
+```js
+import { MinzeElement } from 'minze'
+
+export class MyElement extends MinzeElement {
+  options = {
+    cssReset: true, // Applies CSS reset styles to the components Shadow DOM template.
+    debug: false, // Activates debug mode on the component, check the web console for output.
+    exposeAttrs: {
+      exportparts: false, // Automatically exports all parts present in the template. E.g. <my-element exportparts="button, headline"></my-element>
+      rendered: false // After the component is rendered for the first time, exposes a 'rendered' attribute on the element. E.g. <my-element rendered></my-element>
+    }
   }
 }
 ```

--- a/docs/api/minze-element.md
+++ b/docs/api/minze-element.md
@@ -165,6 +165,7 @@ import { MinzeElement } from 'minze'
 export class MyElement extends MinzeElement {
   options = {
     cssReset: true, // Applies CSS reset styles to the components Shadow DOM template.
+    debug: false, // Activates debug mode on the component, check the web console for output.
     exposeAttrs: {
       exportparts: false, // Automatically exports all parts present in the template. E.g. <my-element exportparts="button, headline"></my-element>
       rendered: false // After the component is rendered for the first time, exposes a 'rendered' attribute on the element. E.g. <my-element rendered></my-element>

--- a/docs/guide/advanced-debugging.md
+++ b/docs/guide/advanced-debugging.md
@@ -1,0 +1,49 @@
+# Debugging
+
+## Options
+
+The component logs useful information about itself to the console when the `debug` option inside the component is set to `true`.
+
+**Example**
+
+```js
+import { MinzeElement } from 'minze'
+
+class MyElement extends MinzeElement {
+  options = { debug: true } // [!code ++]
+}
+
+MyElement.define()
+```
+
+```html
+<my-element></my-element>
+```
+
+## debugger
+
+The `debugger` statement, invokes any available debugging functionality.
+
+::: warning
+Browser DevTools needs to be open for this to work.
+:::
+
+**Example**
+
+```js
+import { MinzeElement } from 'minze'
+
+class MyElement extends MinzeElement {
+  onStart() {
+    let value = 1
+    debugger // [!code ++]
+    value++
+  }
+}
+
+MyElement.define()
+```
+
+```html
+<my-element></my-element>
+```

--- a/docs/guide/components-options.md
+++ b/docs/guide/components-options.md
@@ -7,11 +7,7 @@ import { MinzeElement } from 'minze'
 
 class MyElement extends MinzeElement {
   options = {
-    cssReset: true,
-    exposeAttrs: {
-      exportparts: true,
-      rendered: true
-    }
+    // ...
   }
 }
 

--- a/packages/minze/src/lib/minze-element.ts
+++ b/packages/minze/src/lib/minze-element.ts
@@ -80,6 +80,38 @@ export class MinzeElement extends HTMLElement {
   }
 
   /**
+   * The class name of the component instance in dash-case.
+   *
+   * @example
+   * ```
+   * class MyElement extends MinzeElement {
+   *   onStart() {
+   *     console.log(this.dashName) // my-element
+   *   }
+   * }
+   * ```
+   */
+  get dashName() {
+    return camelToDash(this.constructor.name)
+  }
+
+  /**
+   * The class name of the component instance.
+   *
+   * @example
+   * ```
+   * class MyElement extends MinzeElement {
+   *   onStart() {
+   *     console.log(this.name) // MyElement
+   *   }
+   * }
+   * ```
+   */
+  get name() {
+    return this.constructor.name
+  }
+
+  /**
    * Registers element as a custom web component.
    *
    * @param name - The name of the custom web component.

--- a/packages/minze/src/lib/minze-element.ts
+++ b/packages/minze/src/lib/minze-element.ts
@@ -133,11 +133,12 @@ export class MinzeElement extends HTMLElement {
   /**
    * Defines options for the web component.
    *
-   * @example
+   * @default
    * ```
    * MyElement extends MinzeElement {
    *   options = {
    *     cssReset: true,
+   *     debug: false,
    *     exposeAttrs: {
    *       exportparts: false
    *       rendered: false
@@ -148,6 +149,7 @@ export class MinzeElement extends HTMLElement {
    */
   options?: {
     cssReset?: boolean
+    debug?: boolean
     exposeAttrs?: {
       exportparts?: boolean
       rendered?: boolean

--- a/packages/minze/src/lib/minze-element.ts
+++ b/packages/minze/src/lib/minze-element.ts
@@ -885,6 +885,58 @@ export class MinzeElement extends HTMLElement {
   }
 
   /**
+   * Logs debug information to the console.
+   *
+   * @example
+   * ```
+   * this.debug()
+   * ```
+   */
+  private debug() {
+    if (!console) return
+
+    const hooks = Object.fromEntries(
+      [
+        'onStart',
+        'onReactive',
+        'beforeRender',
+        'onRender',
+        'onReady',
+        'onDestroy',
+        'onMove',
+        'beforeAttributeChange',
+        'onAttributeChange'
+      ]
+        .filter((key) => this[key])
+        .map((key) => [[key], this[key]])
+    )
+
+    console.groupCollapsed(
+      `%c[Minze: ${this.name}]`,
+      'color: rgb(110, 150, 245);'
+    )
+    ;[
+      ['Class: %O', this],
+      ['Element: %o', this]
+    ].forEach(([msg, value]) => console.log(msg, value))
+
+    console.groupCollapsed('Internals')
+    ;[
+      ['hooks: %o', hooks],
+      ['eventListeners: %o', this.eventListeners],
+      ['options: %o', this.options],
+      [
+        'reactive: %o',
+        { attrs: this.attrs, reactive: this.reactive, watch: this.watch }
+      ],
+      ['template: %o', { css: this.css, html: this.html }]
+    ].forEach(([msg, value]) => console.log(msg, value))
+
+    console.groupEnd()
+    console.groupEnd()
+  }
+
+  /**
    * Lifecycle (Internal) - Runs whenever the element is appended into a document-connected element.
    */
   private async connectedCallback() {
@@ -906,6 +958,8 @@ export class MinzeElement extends HTMLElement {
     if (this.options?.exposeAttrs?.rendered) this.setAttribute('rendered', '')
 
     this.onReady?.()
+
+    if (this.options?.debug) this.debug()
   }
 
   /**

--- a/packages/minze/src/lib/minze-element.ts
+++ b/packages/minze/src/lib/minze-element.ts
@@ -570,7 +570,7 @@ export class MinzeElement extends HTMLElement {
     exposeAttr?: boolean
   ) {
     const rootName = name
-    const stashName = `_$reactive-primitive-${name}`
+    const stashName = `_$reactive-${name}`
     this[stashName] = prop
 
     // expose attribute
@@ -661,7 +661,7 @@ export class MinzeElement extends HTMLElement {
       return
     }
 
-    const stashName = `_$reactive-attr-${camelName}`
+    const stashName = `_$attr-${camelName}`
     this[stashName] = rootProp
 
     // set an attribute on the element if no attribute exists

--- a/packages/minze/src/lib/minze-element.ts
+++ b/packages/minze/src/lib/minze-element.ts
@@ -570,8 +570,7 @@ export class MinzeElement extends HTMLElement {
     exposeAttr?: boolean
   ) {
     const rootName = name
-    const stashPrefix = '$minze_stash_prop_'
-    const stashName = `${stashPrefix}${name}`
+    const stashName = `_$reactive-primitive-${name}`
     this[stashName] = prop
 
     // expose attribute
@@ -662,8 +661,7 @@ export class MinzeElement extends HTMLElement {
       return
     }
 
-    const stashPrefix = '$minze_stash_attr_'
-    const stashName = `${stashPrefix}${camelName}`
+    const stashName = `_$reactive-attr-${camelName}`
     this[stashName] = rootProp
 
     // set an attribute on the element if no attribute exists

--- a/packages/minze/src/lib/minze-element.ts
+++ b/packages/minze/src/lib/minze-element.ts
@@ -312,7 +312,7 @@ export class MinzeElement extends HTMLElement {
   /**
    * Stores the previously rendered template.
    */
-  private cachedTemplate: string | null = null
+  private _cachedTemplate?: string | null
 
   /**
    * Renders the template into the shadow DOM.
@@ -330,9 +330,9 @@ export class MinzeElement extends HTMLElement {
     if (this.shadowRoot) {
       const template = this.template()
 
-      if (template !== this.cachedTemplate || force) {
-        const previousCachedTemplate = this.cachedTemplate
-        this.cachedTemplate = template // cache early
+      if (template !== this._cachedTemplate || force) {
+        const previousCachedTemplate = this._cachedTemplate
+        this._cachedTemplate = template // cache early
 
         await this.beforeRender?.()
 
@@ -912,7 +912,7 @@ export class MinzeElement extends HTMLElement {
    * Lifecycle (Internal) - Runs each time the element is disconnected from the document's DOM.
    */
   private async disconnectedCallback() {
-    this.cachedTemplate = null
+    this._cachedTemplate = null
 
     if (this.options?.exposeAttrs?.exportparts) {
       this.registerExportpartsObserver('remove')


### PR DESCRIPTION
<!-- Thank's for contributing! -->

### Description

This PR includes/adds:

- feat: a `debug` option, to toggle a debug log for a specific component
- feat: new instance `name` and `dashName` properties
- internal: name change of the stash prefixes
- internal: cachedTemplate name change
- docs: debugging guide
- docs: MinzeElement API improvements

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/n6ai/minze/blob/main/.github/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/n6ai/minze/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/n6ai/minze/blob/main/.github/COMMIT_CONVENTION.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
