### PR TITLE
feat: simplify the process of defining individual modules from module-maps

### DIFF
--- a/docs/api/minze.md
+++ b/docs/api/minze.md
@@ -54,7 +54,7 @@ Your component class names should be in `PascalCase` when using this registratio
 
 - **Method**
 
-- **Type:** `(elements: (typeof MinzeElement)[] | Record<string, unknown | (() => Promise<Record<string, unknown>>)>): void`
+- **Type:** `(elementsOrModules: (typeof MinzeElement)[] | Record<string, unknown | (() => Promise<unknown>)>, filter?: string[], mapRE?: RegExp): void`
 
 - **Example:**
 

--- a/docs/api/minze.md
+++ b/docs/api/minze.md
@@ -46,7 +46,7 @@ Minze.define('my-element', MyElement)
 
 ### defineAll <Badge type="tip" text="^1.0.0" />
 
-Defines all custom web components in a single call. Your components will be registered with `dash-case` naming.
+Defines all custom web components in a single call. Your components will be registered with `dash-case` naming. The provided compnents can either be an array of Minze Elements, a module object, or a module-map generated with tools like vite's `import.meta.glob`
 
 ::: warning
 Your component class names should be in `PascalCase` when using this registration method.
@@ -58,31 +58,30 @@ Your component class names should be in `PascalCase` when using this registratio
 
 - **Example:**
 
-```js
-import { Minze, MinzeElement } from 'minze'
+::: code-group
 
-class MyFirstElement extends MinzeElement {
-  // ...
-}
-
-class MySecondElement extends MinzeElement {
-  // ...
-}
+```js [Array]
+import { Minze } from 'minze'
+import { MyFirstElement, MySecondElement } from './elements.js'
 
 Minze.defineAll([MyFirstElement, MySecondElement])
 ```
 
-<!-- prettier-ignore-start -->
-```html
-<my-first-element></my-first-element>
-<my-second-element></my-second-element>
+```js [Module]
+import { Minze } from 'minze'
+import * as elements from './elements.js'
+
+Minze.defineAll(elements)
 ```
-<!-- prettier-ignore-end -->
 
-- **Modules Example:**
+```js [Module-Map]
+import { Minze } from 'minze'
+const modules = import.meta.glob('./lib/**/*.@(ts|js)') // vite specific
 
-```js
-// elements.js
+Minze.defineAll(modules)
+```
+
+```js [elements.js]
 import { MinzeElement } from 'minze'
 
 export class MyFirstElement extends MinzeElement {
@@ -94,12 +93,7 @@ export class MySecondElement extends MinzeElement {
 }
 ```
 
-```js
-import { Minze } from 'minze'
-import * as elements from './elements'
-
-Minze.defineAll(elements)
-```
+:::
 
 <!-- prettier-ignore-start -->
 ```html

--- a/docs/api/minze.md
+++ b/docs/api/minze.md
@@ -54,7 +54,7 @@ Your component class names should be in `PascalCase` when using this registratio
 
 - **Method**
 
-- **Type:** `(elementsOrModules: (typeof MinzeElement)[] | Record<string, unknown | (() => Promise<unknown>)>, filter?: string[], mapRE?: RegExp): void`
+- **Type:** `(elementsOrModules: (typeof MinzeElement)[] | Record<string, unknown | (() => Promise<unknown>)>, filter?: string[], mapRE?: RegExp | false | null)`
 
 - **Example:**
 

--- a/docs/guide/publishing.md
+++ b/docs/guide/publishing.md
@@ -67,12 +67,17 @@ import { modules, defineAll } from 'my-package'
 defineAll(modules)
 ```
 
-```js [Define Separate]
-import { MyElement } from 'my-package/dist/lib/my-element'
-import { MyElementTwo } from 'my-package/dist/lib/my-element-two'
+```js [Define Individual]
+import { modules, defineAll } from 'my-package'
+defineAll(modules, ['my-element', 'nested/my-element-two'])
+```
 
-MyElement.define()
-MyElementTwo.define()
+```txt [Source Files]
+src/
+└─ lib/
+   ├─ nested/
+   |  └─ my-element-two.js // [!code ++]
+   └─ my-element.js // [!code ++]
 ```
 
 :::
@@ -83,6 +88,14 @@ MyElementTwo.define()
 ```
 
 <!-- prettier-ignore-end -->
+
+::: tip
+You can provide an array of shorthand file-paths as the second argument to the `defineAll` function, to define individual elements.
+
+The paths are derived from the directory structure of the source files.
+
+Every path starts from the `src/lib/` directory and ends without the file-extension. E.g. for `src/lib/nested/some-element.js` it's `nested/some-element`.
+:::
 
 ### CDN
 
@@ -132,7 +145,7 @@ If you have published your package to npm, you can also load it via a CDN link f
 </html>
 ```
 
-```html [Define Separate]
+```html [Define Individual]
 <html>
   <head></head>
   <body>
@@ -142,14 +155,19 @@ If you have published your package to npm, you can also load it via a CDN link f
 
     <!-- js code -->
     <script type="module">
-      import { defineAll } from 'https://esm.sh/my-package'
-      import { MyElement } from 'https://esm.sh/my-package/dist/lib/my-element.js'
-      import { MyElementTwo } from 'https://esm.sh/my-package/dist/lib/my-element-two.js'
-
-      defineAll([MyElement, MyElementTwo])
+      import { modules, defineAll } from 'https://esm.sh/my-package'
+      defineAll(modules, ['my-element', 'nested/my-element-two'])
     </script>
   </body>
 </html>
+```
+
+```txt [Source Files]
+src/
+└─ lib/
+   ├─ nested/
+   |  └─ my-element-two.js // [!code ++]
+   └─ my-element.js // [!code ++]
 ```
 
 :::

--- a/docs/guide/publishing.md
+++ b/docs/guide/publishing.md
@@ -94,7 +94,7 @@ You can provide an array of shorthand file-paths as the second argument to the `
 
 The paths are derived from the directory structure of the source files.
 
-Every path starts from the `src/lib/` directory and ends without the file-extension. E.g. for `src/lib/nested/some-element.js` it's `nested/some-element`.
+Every path starts from the `src/lib/` directory (no starting slash) and ends without the file-extension. E.g. for `src/lib/nested/some-element.js` it's `nested/some-element`.
 :::
 
 ### CDN

--- a/packages/create-minze/template-storybook-ts/tsconfig.json
+++ b/packages/create-minze/template-storybook-ts/tsconfig.json
@@ -7,7 +7,10 @@
     "strict": true,
     "noImplicitAny": false,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": ["./src/**/*.ts", "./types/**/*.ts"]
 }

--- a/packages/create-minze/template-storybook-ts/vite.config.ts
+++ b/packages/create-minze/template-storybook-ts/vite.config.ts
@@ -1,8 +1,12 @@
 import { defineConfig } from 'vite'
+import { fileURLToPath, URL } from 'url'
 import minze from '@minzejs/vite-plugin-minze'
 import dts from 'vite-plugin-dts'
 
 export default defineConfig({
+  resolve: {
+    alias: { '@': fileURLToPath(new URL('./src', import.meta.url)) }
+  },
   plugins: [
     minze(),
     dts({

--- a/packages/create-minze/template-storybook/jsconfig.json
+++ b/packages/create-minze/template-storybook/jsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/packages/create-minze/template-storybook/vite.config.js
+++ b/packages/create-minze/template-storybook/vite.config.js
@@ -1,6 +1,10 @@
 import { defineConfig } from 'vite'
+import { fileURLToPath, URL } from 'url'
 import minze from '@minzejs/vite-plugin-minze'
 
 export default defineConfig({
+  resolve: {
+    alias: { '@': fileURLToPath(new URL('./src', import.meta.url)) }
+  },
   plugins: [minze()]
 })

--- a/packages/create-minze/template-vite-ts/tsconfig.json
+++ b/packages/create-minze/template-vite-ts/tsconfig.json
@@ -7,7 +7,10 @@
     "strict": true,
     "noImplicitAny": false,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": ["./src/**/*.ts", "./types/**/*.ts"]
 }

--- a/packages/create-minze/template-vite-ts/vite.config.ts
+++ b/packages/create-minze/template-vite-ts/vite.config.ts
@@ -1,8 +1,12 @@
 import { defineConfig } from 'vite'
+import { fileURLToPath, URL } from 'url'
 import minze from '@minzejs/vite-plugin-minze'
 import dts from 'vite-plugin-dts'
 
 export default defineConfig({
+  resolve: {
+    alias: { '@': fileURLToPath(new URL('./src', import.meta.url)) }
+  },
   plugins: [
     minze(),
     dts({

--- a/packages/create-minze/template-vite/jsconfig.json
+++ b/packages/create-minze/template-vite/jsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/packages/create-minze/template-vite/vite.config.js
+++ b/packages/create-minze/template-vite/vite.config.js
@@ -1,6 +1,10 @@
 import { defineConfig } from 'vite'
+import { fileURLToPath, URL } from 'url'
 import minze from '@minzejs/vite-plugin-minze'
 
 export default defineConfig({
+  resolve: {
+    alias: { '@': fileURLToPath(new URL('./src', import.meta.url)) }
+  },
   plugins: [minze()]
 })

--- a/packages/minze/src/lib/minze.ts
+++ b/packages/minze/src/lib/minze.ts
@@ -32,10 +32,10 @@ export class Minze {
    * All class names have to be in PascalCase for automatic dash-case name conversion.
    * Example: `MinzeElement` will be registered as `<minze-element></minze-element>`.
    *
-   * The parameters filter and mapRE are only used if elementsOrModules is actually a module.
+   * The parameters filter and mapRE have only an effect when elementsOrModules is actually a generated module-map. E.g. Object returned by vite `import.meta.glob`.
    *
-   * @param elementsOrModules - A module object or an array of Minze elements.
-   * @param filter - An array of strings that narrows down which modules should be defined.
+   * @param elementsOrModules - A module object, a module-map or an array of Minze elements.
+   * @param filter - An array of strings that narrows down which modules of a module-map should be defined.
    * @param mapRE - A regular expression that is used to strip the matches from the module keys.
    *
    * @default
@@ -43,16 +43,17 @@ export class Minze {
    *
    * @example
    * ```
-   * import * as elements from './module'
-   * Minze.defineAll(elements)
-   *
-   * // or
-   * import { MinzeElement, MinzeElementTwo } from './module'
+   * // array
+   * import { MinzeElement, MinzeElementTwo } from './elements'
    * Minze.defineAll([ MinzeElement, MinzeElementTwo ])
    *
-   * // or for vite glob import
+   * // module
+   * import * as elements from './elements'
+   * Minze.defineAll(elements)
+   *
+   * // module-map (vite)
    * const modules = import.meta.glob('./lib/*.@(ts|js)')
-   * Minze.defineAll(modules, ['first-module', 'second-module'])
+   * Minze.defineAll(modules)
    * ```
    */
   static defineAll(

--- a/packages/minze/src/lib/minze.ts
+++ b/packages/minze/src/lib/minze.ts
@@ -32,7 +32,14 @@ export class Minze {
    * All class names have to be in PascalCase for automatic dash-case name conversion.
    * Example: `MinzeElement` will be registered as `<minze-element></minze-element>`.
    *
-   * @param elements - A module object or an array of custom Minze elements.
+   * The parameters filter and mapRE are only used if elementsOrModules is actually a module.
+   *
+   * @param elementsOrModules - A module object or an array of Minze elements.
+   * @param filter - An array of strings that narrows down which modules should be defined.
+   * @param mapRE - A regular expression that is used to strip the matches from the module keys.
+   *
+   * @default
+   * mapRE = /^\.\/lib\/|\.(ts|js)$/gi
    *
    * @example
    * ```
@@ -44,40 +51,75 @@ export class Minze {
    * Minze.defineAll([ MinzeElement, MinzeElementTwo ])
    *
    * // or for vite glob import
-   * const modules = import.meta.glob('./lib/*.(ts|js)')
-   * Minze.defineAll(modules)
+   * const modules = import.meta.glob('./lib/*.@(ts|js)')
+   * Minze.defineAll(modules, ['first-module', 'second-module'])
    * ```
    */
   static defineAll(
-    elements:
+    elementsOrModules:
       | (typeof MinzeElement)[]
-      | Record<string, unknown | (() => Promise<unknown>)>
+      | Record<string, unknown | (() => Promise<unknown>)>,
+    filter?: string[],
+    mapRE: RegExp = /^\.\/lib\/|\.(ts|js)$/gi
   ) {
-    Object.values(elements).forEach(async (element) => {
+    if (
+      !Array.isArray(elementsOrModules) &&
+      Array.isArray(filter) &&
+      filter.every((x) => typeof x === 'string')
+    ) {
+      elementsOrModules = Minze.enhanceModules(elementsOrModules, filter, mapRE)
+    }
+
+    Object.values(elementsOrModules).forEach(async (elOrM) => {
       if (
-        typeof element === 'function' &&
-        'isMinzeElement' in element &&
-        'define' in element &&
-        typeof element.define === 'function'
+        typeof elOrM === 'function' &&
+        'define' in elOrM &&
+        typeof elOrM.define === 'function'
       ) {
-        element.define()
-      } else if (typeof element === 'object' || typeof element === 'function') {
-        const module = typeof element === 'function' ? await element() : element
+        elOrM.define()
+      } else if (typeof elOrM === 'object' || typeof elOrM === 'function') {
+        const module = typeof elOrM === 'function' ? await elOrM() : elOrM
 
         if (typeof module === 'object') {
-          Object.values(module).forEach(async (value) => {
+          Object.values(module).forEach(async (el) => {
             if (
-              typeof value === 'function' &&
-              'isMinzeElement' in value &&
-              'define' in value &&
-              typeof value.define === 'function'
+              typeof el === 'function' &&
+              'define' in el &&
+              typeof el.define === 'function'
             ) {
-              value.define()
+              el.define()
             }
           })
         }
       }
     })
+  }
+
+  /**
+   * Creates an enhanced consumable map of modules for `Minze.defineAll`.
+   *
+   * @param modules - A module object.
+   * @param filter - An array of strings that narrows down which modules should be included.
+   * @param mapRE - A regular expression that is used to strip the matches from the module keys.
+   *
+   * @example
+   * ```
+   * Minze.enhanceModules(modules, ['first-module', 'second-module'], /^\.\/lib\/|\.(ts|js)$/gi)
+   * ```
+   */
+  private static enhanceModules(
+    modules: Record<string, unknown | (() => Promise<unknown>)>,
+    filter?: string[],
+    mapRE?: RegExp
+  ) {
+    return Object.fromEntries(
+      Object.entries(modules)
+        .map(([k, v]) => {
+          if (mapRE) k = k.replace(mapRE, '')
+          return filter?.includes(k) || !filter ? [k, v] : []
+        })
+        .filter((arr) => arr.length)
+    )
   }
 
   /**

--- a/packages/minze/src/lib/minze.ts
+++ b/packages/minze/src/lib/minze.ts
@@ -60,7 +60,7 @@ export class Minze {
       | (typeof MinzeElement)[]
       | Record<string, unknown | (() => Promise<unknown>)>,
     filter?: string[],
-    mapRE: RegExp = /^\.\/lib\/|\.(ts|js)$/gi
+    mapRE: RegExp | false | null = /^\.\/lib\/|\.(ts|js)$/gi
   ) {
     if (
       !Array.isArray(elementsOrModules) &&
@@ -110,7 +110,7 @@ export class Minze {
   private static enhanceModules(
     modules: Record<string, unknown | (() => Promise<unknown>)>,
     filter?: string[],
-    mapRE?: RegExp
+    mapRE?: RegExp | false | null
   ) {
     return Object.fromEntries(
       Object.entries(modules)

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -7,7 +7,10 @@
     "strict": true,
     "noImplicitAny": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": ["./src/**/*.ts", "./types/**/*.ts"]
 }

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -1,8 +1,12 @@
 import { defineConfig } from 'vite'
+import { fileURLToPath, URL } from 'url'
 import minze from '@minzejs/vite-plugin-minze'
 import dts from 'vite-plugin-dts'
 
 export default defineConfig({
+  resolve: {
+    alias: { '@': fileURLToPath(new URL('./src', import.meta.url)) }
+  },
   plugins: [
     minze(),
     dts({


### PR DESCRIPTION
<!-- Thank's for contributing! -->

### Description

This PR adds/includes:
- simplify individual element registration for module-maps generated with tools like vite's `import.meta.glob`
- add `@` path alias for `src/` dir to CLI templates `jsconfig`, `tsconfig`, `vite.config`
- documentation update for Publishing and Minze API `defineAll`

**Example**
```js
import { Minze } from 'minze'
const modules = import.meta.glob('./lib/**/*.@(ts|js)')

Minze.defineAll(modules, ['my-first-element', 'my-second-element'])
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/n6ai/minze/blob/main/.github/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/n6ai/minze/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/n6ai/minze/blob/main/.github/COMMIT_CONVENTION.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
