### PR TITLE
fix: event shorthand regex breaking events if attribute value matches event shorthand writing

### DIFF
--- a/packages/minze/src/lib/minze-element.ts
+++ b/packages/minze/src/lib/minze-element.ts
@@ -804,7 +804,8 @@ export class MinzeElement extends HTMLElement {
     type onEvent = [attribute: string, event: string, callback: string]
 
     // get all on:event attributes and remove duplicates
-    const onEventsRE = /(?:on:|@)([\w\-:.]+)(?:=(?:"|')?(\w+)(?:"|')?)?/gi
+    const onEventsRE =
+      /\s(?:on:|@)([\w\-:.]+)(?:=(?:"|')?(\w+)(?:"|')?)?(\s|\/)/gi
     const onEvents: onEvent[] = [
       ...new Set(
         [...template.matchAll(onEventsRE)].map((m) =>


### PR DESCRIPTION
event shorthand regex breaking events if attribute value matches event shorthand writing

<!-- Thank's for contributing! -->

### Description

Current regex hits even values of the attributes when it's not supposed to.

### Additional context
I have documented it more here: https://github.com/n6ai/minze/discussions/267

#### Problematic REGEX:
![Screenshot from 2023-11-27 14-25-23](https://github.com/n6ai/minze/assets/10507786/895771b1-db08-453d-a987-1029ab14ed73)

#### I fixed it with this:
![Screenshot from 2023-11-27 15-44-02](https://github.com/n6ai/minze/assets/10507786/3af09e37-3fec-4a7e-afb2-23091e90bc63)

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/n6ai/minze/blob/main/.github/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/n6ai/minze/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/n6ai/minze/blob/main/.github/COMMIT_CONVENTION.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
